### PR TITLE
refactor: remove unecessary explicit promise return

### DIFF
--- a/src/data/usecases/add-account/db-add-account.spec.ts
+++ b/src/data/usecases/add-account/db-add-account.spec.ts
@@ -5,7 +5,7 @@ import { AddAccountRepository } from '../../protocols/add-account-repository'
 const makeEncrypter = (): Encrypter => {
   class EncrypterStub implements Encrypter {
     async encrypt (value: string): Promise<string> {
-      return new Promise(resolve => resolve('hashed_password'))
+      return 'hashed_password'
     }
   }
   return new EncrypterStub()
@@ -14,7 +14,7 @@ const makeEncrypter = (): Encrypter => {
 const makeAddAccountRepository = (): AddAccountRepository => {
   class AddAccountRepositoryStub implements AddAccountRepository {
     async add (accountData: AddAccountModel): Promise<AccountModel> {
-      return new Promise(resolve => resolve(makeFakeAccount()))
+      return makeFakeAccount()
     }
   }
   return new AddAccountRepositoryStub()

--- a/src/infra/criptography/bcrypt-adapter.spec.ts
+++ b/src/infra/criptography/bcrypt-adapter.spec.ts
@@ -3,7 +3,7 @@ import { BcryptAdapter } from './bcrypt-adapter'
 
 jest.mock('bcrypt', () => ({
   async hash (): Promise<string> {
-    return new Promise(resolve => resolve('hash'))
+    return 'hash'
   }
 }))
 

--- a/src/main/decorators/log.spec.ts
+++ b/src/main/decorators/log.spec.ts
@@ -7,7 +7,7 @@ import { LogControllerDecorator } from './log'
 const makeController = (): Controller => {
   class ControllerStub implements Controller {
     async handle (httpRequest: HttpResponse): Promise<HttpResponse> {
-      return new Promise(resolve => resolve(ok(makeFakeAccount())))
+      return ok(makeFakeAccount())
     }
   }
   return new ControllerStub()
@@ -15,9 +15,7 @@ const makeController = (): Controller => {
 
 const makeLogErrorRepository = (): LogErrorRepository => {
   class LogErrorRepositoryStub implements LogErrorRepository {
-    async logError (stack: string): Promise<void> {
-      return new Promise(resolve => resolve())
-    }
+    async logError (stack: string): Promise<void> {}
   }
   return new LogErrorRepositoryStub()
 }

--- a/src/presentation/controllers/login/login.ts
+++ b/src/presentation/controllers/login/login.ts
@@ -14,17 +14,17 @@ export class LoginController implements Controller {
     const { email, password } = httpRequest.body
 
     if (!email) {
-      return new Promise(resolve => resolve(badRequest(new MissingParamError('email'))))
+      return badRequest(new MissingParamError('email'))
     }
 
     if (!password) {
-      return new Promise(resolve => resolve(badRequest(new MissingParamError('password'))))
+      return badRequest(new MissingParamError('password'))
     }
 
     const isValid = this.emailValidator.isValid(email)
 
     if (!isValid) {
-      return new Promise(resolve => resolve(badRequest(new InvalidParamError('email'))))
+      return badRequest(new InvalidParamError('email'))
     }
   }
 }

--- a/src/presentation/controllers/signup/signup.spec.ts
+++ b/src/presentation/controllers/signup/signup.spec.ts
@@ -22,7 +22,7 @@ const makeFakeAccount = (): AccountModel => ({
 const makeAddAccount = (): AddAccount => {
   class AddAccountStub implements AddAccount {
     async add (account: AddAccountModel): Promise<AccountModel> {
-      return new Promise(resolve => resolve(makeFakeAccount()))
+      return makeFakeAccount()
     }
   }
   return new AddAccountStub()


### PR DESCRIPTION
Funções com a assinatura `async` já retornam por padrão uma promise, dessa maneira não é preciso sempre retornar de forma explicita uma instancia de `Promise`.

Desse modo acho que deixa o código mais simples, o que acha ?